### PR TITLE
Make 'div' the default of tagName

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -3,6 +3,7 @@
 ## domManager.create
 
 - Update how after and before work so can work for children of the first-generation elements (@lindelwa122 in #49)
+- Make 'div' the default of tagName (@lindelwa122 in #48)
 
 ## domManager.update
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -30,7 +30,7 @@ The `create` function generates an HTML element based on the provided `element` 
 
 1. `element` (`Object`): An object providing information about the element to be created. It should have the following properties:
 
-   - `tagName` (`string`, required): Specifies the type of HTML element to create.
+   - `tagName` (`string`): Specifies the type of HTML element to create. The default value is `div` because it is commonly used.
    - `children` (`Array`): An array of child elements to be appended to the created element.
    - `options` (`Object`): Additional options for configuring the element (e.g., `classList`, `id`, `link`, `onclick`).
    - `before` (`function`): Function to be invoked before the element is appended to the page.

--- a/dom-wizard.d.ts
+++ b/dom-wizard.d.ts
@@ -11,7 +11,7 @@ declare module 'dom-wizard' {
   };
 
   type ElementDefinition = {
-    tagName: string;
+    tagName?: string;
     options?: ElementOptions;
     link?: LinkConfig;
     children?: Array<ElementDefinition>;

--- a/modules/domManager.js
+++ b/modules/domManager.js
@@ -12,14 +12,9 @@ const domManager = () => {
    *
    * @param {Object} element - An object with information about the element to be created (property: 'tagName' is required).
    * @returns {HTMLElement} A newly created HTML element.
-   * @throws Throws an error if 'tagName' is missing, indicating that an element cannot be created without a tagName.
    */
   const _createElement = (element) => {
-    if (!element.tagName) {
-      throw new Error(
-        'tagName is undefined. An element cannot be created without a tagName.',
-      );
-    }
+    if (!element.tagName) element.tagName = 'div';
 
     const el = document.createElement(element.tagName);
 


### PR DESCRIPTION
'div' is the most used element in web development, it makes sense to make it the default of tagName. Make 'text' outside of options because it is widely used.

Issue: #48 